### PR TITLE
Initial version of a travis support module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ steps that have to be taken to restore functionality.
  2. Create new service accounts or new keys for existing account, for
     mlab-sandbox and mlab-staging, downloading the json key files.
  3. Update GCS ACLs, e.g.
-```
+    ```
     gsutil acl ch -R -u \
        legacy-rpm-writer@mlab-sandbox.iam.gserviceaccount.com:WRITE \
        gs://legacy-rpms-mlab-sandbox
-```
+    ```
  4. Tar the SA keys:
     tar cf service-accounts.tar legacy-rpm-writer.mlab*
  5. Encrypt the tar file:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # travis
 A support library for adding deployment automation in travis.
 
+# Creating accounts
+
+From the top level repo (that contains travis as a submodule):
+
+```
+mkdir keys
+./travis/create_service_account.sh \
+    mlab-sandbox cloud-storage-deployer keys/mlab-sandbox.json
+./travis/create_service_account.sh \
+    mlab-staging cloud-storage-deployer keys/mlab-staging.json
+tar --exclude=*.tar* -C keys -cvf keys/service-accounts.tar .
+
+cp ./travis/template-travis.yml .travis.yml
+travis encrypt-file keys/service-accounts.tar --add
+```
+
+Update the .travis.yml template to match your repository and deployment needs.
 
 ## Encrypting files for travis
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,16 @@ steps that have to be taken to restore functionality.
  4. Tar the SA keys:
     tar cf service-accounts.tar legacy-rpm-writer.mlab*
  5. Encrypt the tar file:
-    `travis encrypt-file -f -p service-accounts.tar --repo m-lab/<repo-name>`
+    ```
+    travis encrypt-file -f -p service-accounts.tar --repo m-lab/<repo-name>
+    ```
     Optionally, if you want to provide the keys for some other repos,
     copy the key and iv values into a command like:
+    ```
     travis encrypt-file -f -p service-accounts.tar --key \
       AAA151324478927bbbbbbbbbcccccccccccccdddddddddd53223551235324324 \
       --iv 632451671306d1842843a792250ce707 --repo gfr10598/ndt-support
+    ```
  6. Copy the keys printed when you encrypted the tar file,
     and paste them in place of the three occurances in the script
     commands below.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ From the top level repo (that contains travis as a submodule):
 
 ```
 mkdir keys
-./travis/create_service_account.sh \
+./travis/create_service_account_and_key.sh \
     mlab-sandbox cloud-storage-deployer keys/mlab-sandbox.json
-./travis/create_service_account.sh \
+./travis/create_service_account_and_key.sh \
     mlab-staging cloud-storage-deployer keys/mlab-staging.json
 tar --exclude=*.tar* -C keys -cvf keys/service-accounts.tar .
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # travis
 A support library for adding deployment automation in travis.
+
+
+## Encrypting files for travis
+
+### Recovering if encryption keys are overwritten
+
+Encryption keys may be overwritten by invoking `travis encrypt-file` more than
+once for the same repository.
+
+In the event that the encryption keys are lost, there are a few
+steps that have to be taken to restore functionality.
+
+ 1. If the SA keys are available, skip to step 4.
+ 2. Create new service accounts or new keys for existing account, for
+    mlab-sandbox and mlab-staging, downloading the json key files.
+ 3. Update GCS ACLs, e.g.
+```
+    gsutil acl ch -R -u \
+       legacy-rpm-writer@mlab-sandbox.iam.gserviceaccount.com:WRITE \
+       gs://legacy-rpms-mlab-sandbox
+```
+ 4. Tar the SA keys:
+    tar cf service-accounts.tar legacy-rpm-writer.mlab*
+ 5. Encrypt the tar file:
+    `travis encrypt-file -f -p service-accounts.tar --repo m-lab/<repo-name>`
+    Optionally, if you want to provide the keys for some other repos,
+    copy the key and iv values into a command like:
+    travis encrypt-file -f -p service-accounts.tar --key \
+      AAA151324478927bbbbbbbbbcccccccccccccdddddddddd53223551235324324 \
+      --iv 632451671306d1842843a792250ce707 --repo gfr10598/ndt-support
+ 6. Copy the keys printed when you encrypted the tar file,
+    and paste them in place of the three occurances in the script
+    commands below.
+ 7. Copy the encrypted tar file to the travis directory (where
+    this script is located).
+ 8. Commit to an appropriate branch, generate PR, and send for review.

--- a/create_public_gcs_bucket.sh
+++ b/create_public_gcs_bucket.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# create_public_gcs_bucket.sh creates a new gcs bucket in the currently active
+# GCP project and sets the default ACL to public-read.
+#
+# If the bucket already exists, the ACL is still set to public-read.
+
+BASEDIR="$(dirname "$0")"
+source "${BASEDIR}/support.sh"
+
+set -e
+USAGE="$0 <project> <bucket>"
+PROJECT=${1:?Please provide the GCP project id: $USAGE}
+BUCKET=${2:?Please provide GCP bucket name: $USAGE}
+
+
+# Checks whether the gcs bucket exists.
+function gcs_bucket_exists () {
+  # Use explicit return values (rather than implicit) so we can preserve
+  # `set -e` globally.
+  if gsutil acl get "gs://$1" &> /dev/null ; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+
+function main () {
+  sanity_check_or_die
+
+  if ! gcs_bucket_exists "${BUCKET}" ; then
+    confirm "Really create 'gs://${BUCKET}' in project '${PROJECT}'?"
+    gsutil mb -p $PROJECT -c multi_regional "gs://${BUCKET}"
+  else
+    echo "Confirmed bucket 'gs://${BUCKET}' already exists"
+  fi
+
+  echo "Setting default object ACL to public-read"
+  if ! gsutil defacl set public-read "gs://${BUCKET}" ; then
+    echo "Failed to set default ACL on gs://${BUCKET}"
+    exit 1
+  fi
+}
+
+
+main

--- a/create_service_account_and_key.sh
+++ b/create_service_account_and_key.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Creates a new service account in the given project using a name derived from
+# the current git repository. The service account is assigned the given role.
+#
+# The role should be one of:
+#  * cloud-storage-deployer
+#  * appengine-flexible-deployer
+#
+# After creating the service account and assigning a role, a new key is
+# generated and written to the output file name.
+
+set -e
+
+BASEDIR="$(dirname "$0")"
+source "${BASEDIR}/support.sh"
+
+USAGE="$0 <project> <role> <output-key-file>"
+PROJECT=${1:?Please provide the GCP project id: $USAGE}
+ROLE=${2:?Please provide the role for service account: $USAGE}
+OUTPUT=${3:?Please provide an output filename: $USAGE}
+IAM_CONSOLE=https://console.cloud.google.com/iam-admin/iam/project
+
+
+# Check whether the service account exists.
+function service_account_exists () {
+  # Use explicit return values (rather than implicit) so we can preserve
+  # `set -e` globally.
+  if gcloud --project "${PROJECT}" \
+      iam service-accounts describe "$1" &> /dev/null ; then
+    return 0
+  else
+    return 1
+  fi
+
+}
+
+function main () {
+  sanity_check_or_die
+
+  local name=$( basename `git rev-parse --show-toplevel` )-travis-deploy
+  local account="${name}@${PROJECT}.iam.gserviceaccount.com"
+  local iam_url="${IAM_CONSOLE}?project=${PROJECT}"
+
+  if ! service_account_exists "${account}" ; then
+    confirm "Really create service account '$account' in project '${PROJECT}'?"
+    gcloud --project "${PROJECT}" iam service-accounts create ${name} \
+        --display-name ${name}
+  else
+    echo "$account already exists.."
+  fi
+
+  # Assign the given custom role to the service account. It will appear in:
+  #    GCP Console "IAM & Admin" -> "IAM" page
+  #
+  # Setting the same role if it is already present has no effect.
+  # Note: the role specified here must have all special characters removed.
+  gcloud --project "${PROJECT}" projects add-iam-policy-binding "${PROJECT}" \
+      --member "serviceAccount:${account}" \
+      --role "projects/${PROJECT}/roles/${ROLE//-/}"
+
+  echo "Creating new key for $account"
+  gcloud --project "${PROJECT}" iam service-accounts keys create \
+      --iam-account "${account}" "${OUTPUT}"
+
+  echo "Service account '$account' created with role '$ROLE'"
+  echo ""
+  echo "Visit the GCP IAM & Admin page NOW and verify the configuration."
+  echo ""
+  echo "Service accounts should have the FEWEST PERMISSIONS POSSIBLE."
+  echo ""
+  echo "${iam_url}"
+  google-chrome "${iam_url}" &> /dev/null || :
+}
+
+main

--- a/decrypt.sh
+++ b/decrypt.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This script decrypts an encrypted file.
+
+set -e
+
+USAGE="$0 <iv> <key> <enc-file> <out-file> [out-dir]"
+IV=${1:?Please provide encryption IV: $USAGE}
+KEY=${2:?Please provide encryption KEY: $USAGE}
+INPUT=${3:?Please provide encrypted input filename: $USAGE}
+OUTPUT=${4:?Please provide output filename: $USAGE}
+OUTDIR=${5}
+
+if [[ -n "${IV}" ]] ; then
+  echo "Decrypting: ${INPUT} -> ${OUTPUT}"
+  openssl aes-256-cbc -d -K "${KEY}" -iv "${IV}" -in "${INPUT}" -out "${OUTPUT}"
+  # If OUTPUT is a tar file, then unpack the content into OUTDIR.
+  if [[ -n "${OUTDIR}" && "${OUTPUT}" == *.tar ]] ; then
+      tar -C "${OUTDIR}" -xvf "${OUTPUT}" ;
+  fi
+fi

--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Performs an AppEngine deployment using service account credentials.
+
+set -x
+set -e
+
+PROJECT=${1:?Please provide the GCP project id}
+KEYFILE=${2:?Please provide the service account key file}
+BASEDIR=${3:?Please provide the base directory containing app.yaml}
+
+# Add gcloud to PATH.
+source "${HOME}/google-cloud-sdk/path.bash.inc"
+
+# All operations are performed as the service account named in KEYFILE.
+# For all options see:
+# https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
+gcloud auth activate-service-account --key-file "${KEYFILE}"
+
+# For all options see:
+# https://cloud.google.com/sdk/gcloud/reference/config/set
+gcloud config set core/project "${PROJECT}"
+gcloud config set core/disable_prompts true
+gcloud config set core/verbosity debug
+
+# Make build artifacts available to docker build.
+pushd "${BASEDIR}"
+  # Automatically promote the new version to "serving".
+  # For all options see:
+  # https://cloud.google.com/sdk/gcloud/reference/app/deploy
+  gcloud app deploy --promote app.yaml
+popd
+
+exit 0

--- a/deploy_gcs_copy.sh
+++ b/deploy_gcs_copy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copies local files to a given GCS bucket.
+set -x
+set -e
+
+USAGE="$0 <key-file> <source> <dest>"
+KEYFILE=${1:?Please provide the service account key file: $USAGE}
+SOURCE=${2:?Please provide source pattern: $USAGE}
+GSPATH=${3:?Please provide GCS destination - gs://path: $USAGE}
+
+# Add gcloud to PATH.
+source "${HOME}/google-cloud-sdk/path.bash.inc"
+
+# All operations are performed as the service account named in KEYFILE.
+# For all options see:
+# https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
+gcloud auth activate-service-account --key-file "${KEYFILE}"
+
+# For this to succeed, the specified bucket must have ACLs to allow WRITE
+# access for the service account associated with the keyfile. Update the ACL
+# from a privileged account using:
+#   gsutil acl ch -u SERVICE_ACCT_NAME@PROJECT.iam.gserviceaccount.com:WRITE \
+#      gs://BUCKET
+gsutil cp $SOURCE "gs://${GSPATH}/"
+
+exit 0

--- a/install_gcloud.sh
+++ b/install_gcloud.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Installs the Google Cloud SDK.
+
+set -e
+set -x
+
+if [[ ! -d "${HOME}/google-cloud-sdk/bin" ]]; then
+  rm -rf "${HOME}/google-cloud-sdk"
+
+  export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+  curl https://sdk.cloud.google.com | bash
+
+fi
+
+# Verify installation succeeded.
+source "${HOME}/google-cloud-sdk/path.bash.inc"
+gcloud version

--- a/support.sh
+++ b/support.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Displays a given message requiring user confirmation before continuing.
+function confirm () {
+  local msg=$1
+  read -p "$msg (y/N): " -n 1 -r
+  echo ''
+  if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
+    echo "Not confirmed. Exiting."
+    exit 1
+  fi
+}
+
+
+# Checks that the environment is sane.
+function sanity_check_or_die () {
+  if ! command -v gcloud ; then
+    echo "gcloud not found in PATH. Is the Google Cloud SDK installed?"
+    echo "https://cloud.google.com/sdk/downloads"
+    exit 1
+  fi
+}
+
+

--- a/template-travis.yml
+++ b/template-travis.yml
@@ -1,0 +1,65 @@
+# Travis configuration for <repo>
+#
+# <repo> support release automation to M-Lab GCP projects for branches in the
+# m-lab/<repo> repository. To achieve this, the build takes the following steps:
+#
+#  * decrypt service account credentials, under keys/*.tar.enc
+#  * install the Google Cloud SDK command line tools (gcloud)
+#  * cache the gcloud installation and setup
+#  * test and build the project code
+#  * on success, deploy the result when the origin branch matches a supported
+#    deployment target.
+#
+
+before_install:
+# NB: Encrypted values are not defined in forks or pull requests.
+# Decrypt the tar archive containing the GCP service account key files.
+#
+# After unpacking, there should be one service account key file for every GCP
+# project referenced in the "deploy" section. These keys authenticate the
+# gcloud deploy operations.
+
+# TODO: Update the IV and KEY values for your repository.
+- travis/decrypt.sh $IV $KEY
+  keys/service-accounts.tar.enc /tmp/service-accounts.tar /tmp
+
+# These directories will be cached on successful "script" builds, and restored,
+# if available, to save time on future builds.
+cache:
+  directories:
+    - "$HOME/google-cloud-sdk/"
+
+script:
+- echo "TODO: Update the build and test script for your project."
+- $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
+
+# Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
+# after a merge with matching "on:" conditions.
+deploy:
+# SANDBOX: before code review for development code in a specific branch.
+- provider: script
+  script: $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    /tmp/mlab-sandbox.json
+    $TRAVIS_BUILD_DIR/cmd/epoxy_boot_server
+  skip_cleanup: true
+  on:
+    # TODO: update repo
+    repo: m-lab/<repo>
+    # Consider all branches and match using the condition. By default
+    # "all_branches" is false, and the condition is ignored.
+    all_branches: true
+    # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
+    condition: $TRAVIS_BRANCH == sandbox-*
+
+# STAGING: after code review and before QA testing.
+- provider: script
+  script: $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    /tmp/mlab-staging.json
+    $TRAVIS_BUILD_DIR/cmd/epoxy_boot_server
+  skip_cleanup: true
+  on:
+    # TODO: update repo
+    repo: m-lab/<repo>
+    branch: dev
+
+# PRODUCTION: after code review and after QA tests on staging have passed.


### PR DESCRIPTION
This PR consolidates various scripts needed to support deployment automation from travis builds.

Features supported:

 * creating service accounts with pre-defined roles and a key file
 * a template .travis.yml file and decryption support
 * deploying local files to GCS buckets
 * deploying an AppEngine Flexible Environment service

Changes include:

 * new script `create_public_gcs_bucket.sh`
 * new script `create_service_account_and_key.sh`
 * generalize `decrypt.sh`
 * generalize `deploy_gcs_copy.sh`
 * generalize `template-travis.yml`
 * move and revise comments from `decrypt.sh` to `README.md`
 * unchanged `deploy_app.sh`
 * unchanged `install_gcloud.sh`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/1)
<!-- Reviewable:end -->
