### PR TITLE
Update tar command to work correctly with travis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ mkdir keys
     mlab-sandbox cloud-storage-deployer keys/mlab-sandbox.json
 ./travis/create_service_account_and_key.sh \
     mlab-staging cloud-storage-deployer keys/mlab-staging.json
-tar --exclude=*.tar* -C keys -cvf keys/service-accounts.tar .
+
+# NB: do not include "." in the resulting tar file.
+pushd keys
+  tar --exclude=*.tar* -cvf service-accounts.tar *.json
+popd
 
 cp ./travis/template-travis.yml .travis.yml
 travis encrypt-file keys/service-accounts.tar --add


### PR DESCRIPTION
This change updates the tar command to exclude the "." directory.

Originally, "." was included in the resulting tar archive. And, this resulted in errors when unpacking the archive from travis:
```
tar: .: Cannot utime: Operation not permitted
tar: .: Cannot change mode to rwxr-x--T: Operation not permitted
tar: Exiting with failure status due to previous errors
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/2)
<!-- Reviewable:end -->
