### PR TITLE
Take the gspath parameter as a literal path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ steps that have to be taken to restore functionality.
     mlab-sandbox and mlab-staging, downloading the json key files.
  3. Update GCS ACLs, e.g.
     ```
-    gsutil acl ch -R -u \
+    gsutil acl ch -u \
        legacy-rpm-writer@mlab-sandbox.iam.gserviceaccount.com:WRITE \
        gs://legacy-rpms-mlab-sandbox
     ```

--- a/deploy_gcs_copy.sh
+++ b/deploy_gcs_copy.sh
@@ -22,6 +22,6 @@ gcloud auth activate-service-account --key-file "${KEYFILE}"
 # from a privileged account using:
 #   gsutil acl ch -u SERVICE_ACCT_NAME@PROJECT.iam.gserviceaccount.com:WRITE \
 #      gs://BUCKET
-gsutil cp $SOURCE "gs://${GSPATH}/"
+gsutil cp $SOURCE "${GSPATH}"
 
 exit 0


### PR DESCRIPTION
This change removes the special formatting of the GSPATH and uses the literal value provided by the command line. This makes the invocation of `deploy_gcs_copy.sh` easy to read in context and permits the renaming of files at their destination.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/3)
<!-- Reviewable:end -->
