### PR TITLE
Add support for "beta" app engine deployments to support Go SE.

### DIFF
--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -28,7 +28,7 @@ pushd "${BASEDIR}"
   # Automatically promote the new version to "serving".
   # For all options see:
   # https://cloud.google.com/sdk/gcloud/reference/app/deploy
-  gcloud app deploy --promote app.yaml
+  gcloud ${BETA} app deploy --promote app.yaml
 popd
 
 exit 0


### PR DESCRIPTION
This change adds support `gcloud beta app` by defining an environment variable `BETA`. For example, to deploy a Go SE service, use:

    BETA=beta ./travis/deploy_app.sh .... 

If `BETA` is undefined, then the call to `gcloud` defaults to the standard `app deploy` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/4)
<!-- Reviewable:end -->
