### PR TITLE
Add notes for setting up the travis submodule in a repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # travis
 A support library for adding deployment automation in travis.
 
+# Add submodule to a new repository
+
+So travis can automatically checkout the travis submodule, use the `https`
+address. Think of this as a read-only link to the travis repo.
+
+From the root directory of the repo you're adding to travis:
+```
+git submodule add https://github.com/m-lab/travis.git
+```
+
 # Creating accounts
 
 From the top level repo (that contains travis as a submodule):

--- a/deploy_gcs_copy.sh
+++ b/deploy_gcs_copy.sh
@@ -8,6 +8,7 @@ USAGE="$0 <key-file> <source> <dest>"
 KEYFILE=${1:?Please provide the service account key file: $USAGE}
 SOURCE=${2:?Please provide source pattern: $USAGE}
 GSPATH=${3:?Please provide GCS destination - gs://path: $USAGE}
+GSUTIL_CP_FLAGS=${4}
 
 # Add gcloud to PATH.
 source "${HOME}/google-cloud-sdk/path.bash.inc"
@@ -22,6 +23,6 @@ gcloud auth activate-service-account --key-file "${KEYFILE}"
 # from a privileged account using:
 #   gsutil acl ch -u SERVICE_ACCT_NAME@PROJECT.iam.gserviceaccount.com:WRITE \
 #      gs://BUCKET
-gsutil cp $SOURCE "${GSPATH}"
+gsutil cp ${GSUTIL_CP_FLAGS} ${SOURCE} "${GSPATH}"
 
 exit 0


### PR DESCRIPTION
A short note on adding the travis repo as a submodule to a new repo.

Travis requires the read-only form of the submodule to succeed during travis integration.

Also, allow deploy_gcs_copy.sh to accept flags for `gsutil`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/6)
<!-- Reviewable:end -->
