### PR TITLE
Respect 30-character limit for service names.

### DIFF
--- a/create_service_account_and_key.sh
+++ b/create_service_account_and_key.sh
@@ -38,7 +38,9 @@ function service_account_exists () {
 function main () {
   sanity_check_or_die
 
-  local name=$( basename `git rev-parse --show-toplevel` )-travis-deploy
+  local basename=$( basename `git rev-parse --show-toplevel` )
+  # Service account names can have no more than 30 characters.
+  local name=${basename:0:16}-travis-deploy
   local account="${name}@${PROJECT}.iam.gserviceaccount.com"
   local iam_url="${IAM_CONSOLE}?project=${PROJECT}"
 


### PR DESCRIPTION
This PR updates `create_service_account_and_key.sh` to respect the 30 character limit on service account names.

While this does not seem to be a limitation of the GCP web console, it does appear to be a limitation of the `gcloud` command line tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/15)
<!-- Reviewable:end -->
