### PR TITLE
Add gcloudlib and support deploy_gcs using environment SA keys

### DIFF
--- a/deploy_gcs.sh
+++ b/deploy_gcs.sh
@@ -9,7 +9,6 @@
 #       gs://example-mlab-sandbox/files/
 
 set -e
-set -x
 set -u
 
 USAGE="Usage: $0 <key> <src> <dest>"

--- a/deploy_gcs.sh
+++ b/deploy_gcs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# deploy_gcs supports deploying build artifacts to GCS buckets using base64
+# encoded service account keys, such as those stored in travis-ci environments.
+#
+# Example:
+#   deploy_gcs.sh "$SERVICE_ACCOUNT_mlab_sandbox" \
+#       build/*.rpm \
+#       gs://example-mlab-sandbox/files/
+
+set -e
+set -x
+set -u
+
+USAGE="Usage: $0 <key> <src> <dest>"
+KEY=${1:?Please provide the base64 encoded service account key: $USAGE}
+SRC=${2:?Please provide a source file, dir, or pattern: $USAGE}
+DEST=${3:?Please provide a destination bucket with optional path: $USAGE}
+
+# Import support functions from the bash gcloud library.
+source "${HOME}/google-cloud-sdk/path.bash.inc"
+source $( dirname "${BASH_SOURCE[0]}" )/gcloudlib.sh
+
+# Authenticate all operations using the given service account.
+activate_service_account "${KEY}"
+
+# Copy recursively to GCS with caching disabled.
+copy_nocache ${SRC} ${DEST}

--- a/deploy_gcs.sh
+++ b/deploy_gcs.sh
@@ -3,11 +3,21 @@
 # deploy_gcs supports deploying build artifacts to GCS buckets using base64
 # encoded service account keys, such as those stored in travis-ci environments.
 #
-# Example:
+# Examples:
+#   # Copies all files matching pattern to the named folder, preserving names.
 #   deploy_gcs.sh "$SERVICE_ACCOUNT_mlab_sandbox" \
 #       build/*.rpm \
 #       gs://example-mlab-sandbox/files/
-
+#
+#   # Copies specific file to a folder, preserving the name.
+#   deploy_gcs.sh "$SERVICE_ACCOUNT_mlab_sandbox" \
+#       build/foobar.rpm \
+#       gs://example-mlab-sandbox/files/
+#
+#   # Copies specific file and renames it in GCS.
+#   deploy_gcs.sh "$SERVICE_ACCOUNT_mlab_sandbox" \
+#       build/foobar.rpm \
+#       gs://example-mlab-sandbox/files/foobar-newname.rpm
 set -e
 set -u
 

--- a/gcloudlib.sh
+++ b/gcloudlib.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# A library of common operations around gcloud / gsutil cli.
+
+# activate_service_account takes a base64 encoded service account key, decodes
+# it, and activates it so that future gcloud operations are authenticated using
+# that service account.
+#
+# For more information, see:
+#   https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
+#
+# Args:
+#   key: base64 encoded service account key.
+function activate_service_account() {
+    local key=$1
+    local keyfile=$( mktemp )
+
+    echo $key | base64 --decode > ${keyfile}
+    gcloud auth activate-service-account --key-file ${keyfile}
+    rm -f ${keyfile}
+}
+
+
+# copy_nocache copies src files or directories to the GCS path in dest.
+# Uploaded objects will have metadata set to disable caching.
+#
+# Args:
+#  src: a source specification of a source file, dir, or pattern.
+#  dest: a destination specification, including GCS bucket and optional path.
+function copy_nocache() {
+    local src=$1
+    local dest=$2
+    local cache_control="Cache-Control:private, max-age=0, no-transform"
+    gsutil -h "$cache_control" cp -r ${src} ${dest}
+}


### PR DESCRIPTION
This change adds two new files to the travis repo to support using service account keys stored in travis environment variables.

`gcloudlib.sh` can contain common operations for gcloud or gsutil commands.
`deploy_gcs.sh` uses functions from gcloudlib.sh to activate base64 encoded service account keys to upload uncached files to GCS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/20)
<!-- Reviewable:end -->
