### PR TITLE
Redirects stdout of google-cloud-sdk install process to /dev/null

### DIFF
--- a/install_gcloud.sh
+++ b/install_gcloud.sh
@@ -11,7 +11,7 @@ if [[ ! -d "${HOME}/google-cloud-sdk/bin" ]]; then
   rm -rf "${HOME}/google-cloud-sdk"
 
   export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-  curl https://sdk.cloud.google.com | bash
+  curl https://sdk.cloud.google.com | bash > /dev/null
 
 fi
 


### PR DESCRIPTION
Currently, Travis builds of NDT are immensely verbose, in part due to installing the google-cloud-sdk, which does a verbose untarring of a very large tar file. This should make our Travis logs easier to read, and may even [solve a build bug with the latest Travis Trusty images where hugely copious stdout causes errors](https://github.com/travis-ci/travis-ci/issues/4704).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/21)
<!-- Reviewable:end -->
