### PR TITLE
Load service account key from environment

### DIFF
--- a/deploy_gcs.sh
+++ b/deploy_gcs.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 #
-# deploy_gcs supports deploying build artifacts to GCS buckets using base64
-# encoded service account keys, such as those stored in travis-ci environments.
+# deploy_gcs supports deploying build artifacts to GCS buckets using service
+# account keys from the environment, such as those stored in travis-ci.
 #
 # Examples:
 #   # Copies all files matching pattern to the named folder, preserving names.
-#   deploy_gcs.sh "$SERVICE_ACCOUNT_mlab_sandbox" \
+#   deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox \
 #       build/*.rpm \
 #       gs://example-mlab-sandbox/files/
 #
 #   # Copies specific file to a folder, preserving the name.
-#   deploy_gcs.sh "$SERVICE_ACCOUNT_mlab_sandbox" \
+#   deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox \
 #       build/foobar.rpm \
 #       gs://example-mlab-sandbox/files/
 #
 #   # Copies specific file and renames it in GCS.
-#   deploy_gcs.sh "$SERVICE_ACCOUNT_mlab_sandbox" \
+#   deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox \
 #       build/foobar.rpm \
 #       gs://example-mlab-sandbox/files/foobar-newname.rpm
 set -e
 set -u
 
-USAGE="Usage: $0 <key> <src> <dest>"
-KEY=${1:?Please provide the base64 encoded service account key: $USAGE}
+USAGE="Usage: $0 <keyname> <src> <dest>"
+KEYNAME=${1:?Please provide the service account keyname: $USAGE}
 SRC=${2:?Please provide a source file, dir, or pattern: $USAGE}
 DEST=${3:?Please provide a destination bucket with optional path: $USAGE}
 
@@ -31,7 +31,7 @@ source "${HOME}/google-cloud-sdk/path.bash.inc"
 source $( dirname "${BASH_SOURCE[0]}" )/gcloudlib.sh
 
 # Authenticate all operations using the given service account.
-activate_service_account "${KEY}"
+activate_service_account "${KEYNAME}"
 
 # Copy recursively to GCS with caching disabled.
 copy_nocache ${SRC} ${DEST}

--- a/gcloudlib.sh
+++ b/gcloudlib.sh
@@ -10,12 +10,14 @@
 #   https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
 #
 # Args:
-#   key: base64 encoded service account key.
+#   keyname: name of environment variable that contains a service account key.
 function activate_service_account() {
-    local key=$1
+    local keyname=$1
     local keyfile=$( mktemp )
 
-    echo $key | base64 --decode > ${keyfile}
+    # Unconditionally disable command echo to protect the key. Run in a subshell
+    # to localize the effect of set +x.
+    ( set +x; echo "${!keyname}" > ${keyfile} )
     gcloud auth activate-service-account --key-file ${keyfile}
     rm -f ${keyfile}
 }


### PR DESCRIPTION
This change modifies gcloudlib.sh to expect service account keys to be available from the environment and that the key content is raw json (not encoded with base64 or in any other way obfuscated).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/22)
<!-- Reviewable:end -->
