### PR TITLE
Accept multiple source files

### DIFF
--- a/deploy_gcs.sh
+++ b/deploy_gcs.sh
@@ -29,10 +29,6 @@ if [[ $# -lt 2 ]] ; then
     echo $USAGE
     exit 1
 fi
-# Take all parameters except the last as the sources.
-SRCS=${@:1:$(( $# - 1 ))}
-# Take the last parameter as the destination.
-DEST=${@:$#}
 
 # Import support functions from the bash gcloud library.
 source "${HOME}/google-cloud-sdk/path.bash.inc"
@@ -42,4 +38,4 @@ source $( dirname "${BASH_SOURCE[0]}" )/gcloudlib.sh
 activate_service_account "${KEYNAME}"
 
 # Copy recursively to GCS with caching disabled.
-copy_nocache "${SRCS}" ${DEST}
+copy_nocache $@

--- a/deploy_gcs.sh
+++ b/deploy_gcs.sh
@@ -23,8 +23,16 @@ set -u
 
 USAGE="Usage: $0 <keyname> <src> <dest>"
 KEYNAME=${1:?Please provide the service account keyname: $USAGE}
-SRC=${2:?Please provide a source file, dir, or pattern: $USAGE}
-DEST=${3:?Please provide a destination bucket with optional path: $USAGE}
+shift
+# Ensure there are at least two additional parameters.
+if [[ $# -lt 2 ]] ; then
+    echo $USAGE
+    exit 1
+fi
+# Take all parameters except the last as the sources.
+SRCS=${@:1:$(( $# - 1 ))}
+# Take the last parameter as the destination.
+DEST=${@:$#}
 
 # Import support functions from the bash gcloud library.
 source "${HOME}/google-cloud-sdk/path.bash.inc"
@@ -34,4 +42,4 @@ source $( dirname "${BASH_SOURCE[0]}" )/gcloudlib.sh
 activate_service_account "${KEYNAME}"
 
 # Copy recursively to GCS with caching disabled.
-copy_nocache ${SRC} ${DEST}
+copy_nocache "${SRCS}" ${DEST}

--- a/gcloudlib.sh
+++ b/gcloudlib.sh
@@ -27,11 +27,9 @@ function activate_service_account() {
 # Uploaded objects will have metadata set to disable caching.
 #
 # Args:
-#  src: a source specification of a source file, dir, or pattern.
-#  dest: a destination specification, including GCS bucket and optional path.
+#  copyfiles: the source and dest files, dirs, or patterns.
 function copy_nocache() {
-    local src=$1
-    local dest=$2
+    local copyfiles=$@
     local cache_control="Cache-Control:private, max-age=0, no-transform"
-    gsutil -h "$cache_control" cp -r ${src} ${dest}
+    gsutil -h "$cache_control" cp -r $copyfiles
 }


### PR DESCRIPTION
This change allows `deploy_gcs.sh` to accept multiple source arguments just like `gsutil cp` can.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/23)
<!-- Reviewable:end -->
