### PR TITLE
Do not base64 encode service accounts

### DIFF
--- a/activate_service_account.sh
+++ b/activate_service_account.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# activate_service_account.sh accepts the name of an environment variable whose
+# value contains an unencoded service account key and activates the key to be
+# the default authentication on future gcloud operations.
+set -e
+set -u
+
+USAGE="Usage: $0 <keyname>"
+KEYNAME=${1:?Please provide the service account keyname: $USAGE}
+
+# Import support functions from the bash gcloud library.
+source "${HOME}/google-cloud-sdk/path.bash.inc"
+source $( dirname "${BASH_SOURCE[0]}" )/gcloudlib.sh
+
+# Authenticate all operations using the given service account.
+activate_service_account "${KEYNAME}"

--- a/setup_service_accounts_for_travis.sh
+++ b/setup_service_accounts_for_travis.sh
@@ -158,13 +158,13 @@ function setup_project() {
   local output=$( mktemp /tmp/service-account-json.XXXXXXXX )
   download_service_account_keys "${project}" "${account}" "${output}"
 
-  # Base64 encode the credential file and set a travis environment variable.
-  local encoded_key="$( base64 --wrap 0 ${output} )"
+  # The contents of the credential file.
+  local key="$( cat ${output} )"
   rm -f ${output}
 
   # Create the new environment variable.
   echo "Setting SERVICE_ACCOUNT_${project/-/_}"
-  travis env set --no-interactive SERVICE_ACCOUNT_${project/-/_} "${encoded_key}"
+  travis env set --no-interactive SERVICE_ACCOUNT_${project/-/_} "${key}"
 }
 
 


### PR DESCRIPTION
This change removes the base64 encoding step when creating new service account keys.

Repos that create keys like this should activate the key during a travis build using either the helper script `activate_service_account.sh <KEY NAME>` or use the gcloudlib.sh function `activate_service_account` from more elaborate deployment scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/24)
<!-- Reviewable:end -->
