### PR TITLE
add sed to substitute travis vars

### DIFF
--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -26,6 +26,10 @@ gcloud config set core/verbosity debug
 
 # Make build artifacts available to docker build.
 pushd "${BASEDIR}"
+  # Substitute useful travis env variables into appengine env variables.
+  yaml_text=`cat $APPYAML`
+  echo $yaml_text | sed "s/__COMMIT_HASH__/$TRAVIS_COMMIT/" | sed "s/__RELEASE_TAG__/$TRAVIS_TAG/" > $APPYAML
+
   # Automatically promote the new version to "serving".
   # For all options see:
   # https://cloud.google.com/sdk/gcloud/reference/app/deploy

--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -9,6 +9,8 @@ PROJECT=${1:?Please provide the GCP project id}
 KEYFILE=${2:?Please provide the service account key file}
 BASEDIR=${3:?Please provide the base directory containing app.yaml}
 APPYAML=${4:-app.yaml}
+TRAVIS_COMMIT=${TRAVIS_COMMIT:-unknown}
+TRAVIS_TAG=${TRAVIS_TAG:-empty_tag}
 
 # Add gcloud to PATH.
 source "${HOME}/google-cloud-sdk/path.bash.inc"
@@ -27,8 +29,10 @@ gcloud config set core/verbosity debug
 # Make build artifacts available to docker build.
 pushd "${BASEDIR}"
   # Substitute useful travis env variables into appengine env variables.
-  yaml_text=`cat $APPYAML`
-  echo $yaml_text | sed "s/__COMMIT_HASH__/$TRAVIS_COMMIT/" | sed "s/__RELEASE_TAG__/$TRAVIS_TAG/" > $APPYAML
+  yaml=`cat $APPYAML`
+  yaml=`echo "$yaml" | COMMIT_HASH=$TRAVIS_COMMIT envsubst '$COMMIT_HASH'`
+  yaml=`echo "$yaml" | RELEASE_TAG=$TRAVIS_TAG envsubst '$RELEASE_TAG'`
+  echo "$yaml" > $APPYAML
 
   # Automatically promote the new version to "serving".
   # For all options see:

--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -30,9 +30,7 @@ gcloud config set core/verbosity debug
 pushd "${BASEDIR}"
   # Substitute useful travis env variables into appengine env variables.
   yaml=`cat $APPYAML`
-  yaml=`echo "$yaml" | envsubst '$TRAVIS_TAG'`
-  yaml=`echo "$yaml" | envsubst '$TRAVIS_COMMIT'`
-  echo "$yaml" > $APPYAML
+  `echo "$yaml" | envsubst '$TRAVIS_TAG, $TRAVIS_COMMIT'` > $APPYAML
 
   # Automatically promote the new version to "serving".
   # For all options see:

--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -30,8 +30,8 @@ gcloud config set core/verbosity debug
 pushd "${BASEDIR}"
   # Substitute useful travis env variables into appengine env variables.
   yaml=`cat $APPYAML`
-  yaml=`echo "$yaml" | COMMIT_HASH=$TRAVIS_COMMIT envsubst '$COMMIT_HASH'`
-  yaml=`echo "$yaml" | RELEASE_TAG=$TRAVIS_TAG envsubst '$RELEASE_TAG'`
+  yaml=`echo "$yaml" | envsubst '$TRAVIS_TAG'`
+  yaml=`echo "$yaml" | envsubst '$TRAVIS_COMMIT'`
   echo "$yaml" > $APPYAML
 
   # Automatically promote the new version to "serving".


### PR DESCRIPTION
I'd like to have app engine deployments have access to the travis env vars associated with their deployment.  Does this seem like a suitable way to do that?

Started by doing it in ETL, but that requires lots of repeated code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/25)
<!-- Reviewable:end -->
