### PR TITLE
Adds the build_rpm.sh script to this repo

### DIFF
--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# build_rpm.sh uses a canonical build of the m-lab/builder docker image with a
+# "production" tag.
+#
+# So far, other repos using the m-lab/builder docker image depend on images
+# hosted in the mlab-sandbox GCR. By using dockerhub we avoid managing ACLs on
+# GCR buckets, the need to authenticate with gcloud before using docker commands
+# from travis, and make the builder image more easily accessible to the public.
+
+set -x
+set -e
+
+USAGE="$0 'command to run in builder'"
+_=${1:?Please provide a command to run: $USAGE}
+docker pull measurementlab/builder:production-1.0
+docker run -t -v `pwd`:/root/building \
+    measurementlab/builder:production-1.0 bash -c "cd /root/building; $@"


### PR DESCRIPTION
 This PR moves the build_rpm.sh script from ndt-support repo so that various *-support repos can use it  here (by including this repo as a submodule). There was a TODO in the build_rpm.sh file itself to do this, so I'm just taking care of the TODO. A PR to the ndt-support repo will immediately follow this one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/31)
<!-- Reviewable:end -->
