### PR TITLE
Support raw keys by name in deploy_app.sh

### DIFF
--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -6,7 +6,7 @@ set -x
 set -e
 
 PROJECT=${1:?Please provide the GCP project id}
-KEYFILE=${2:?Please provide the service account key file}
+KEYNAME=${2:?Please provide the service account keyname}
 BASEDIR=${3:?Please provide the base directory containing app.yaml}
 APPYAML=${4:-app.yaml}
 TRAVIS_COMMIT=${TRAVIS_COMMIT:-unknown}
@@ -14,11 +14,10 @@ TRAVIS_TAG=${TRAVIS_TAG:-empty_tag}
 
 # Add gcloud to PATH.
 source "${HOME}/google-cloud-sdk/path.bash.inc"
+source $( dirname "${BASH_SOURCE[0]}" )/gcloudlib.sh
 
-# All operations are performed as the service account named in KEYFILE.
-# For all options see:
-# https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
-gcloud auth activate-service-account --key-file "${KEYFILE}"
+# Authenticate all operations using the given service account.
+activate_service_account "${KEYNAME}"
 
 # For all options see:
 # https://cloud.google.com/sdk/gcloud/reference/config/set

--- a/deploy_app_legacy_keyfile.sh
+++ b/deploy_app_legacy_keyfile.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Performs an AppEngine deployment using service account credentials.
+
+set -x
+set -e
+
+PROJECT=${1:?Please provide the GCP project id}
+KEYFILE=${2:?Please provide the service account key file}
+BASEDIR=${3:?Please provide the base directory containing app.yaml}
+APPYAML=${4:-app.yaml}
+TRAVIS_COMMIT=${TRAVIS_COMMIT:-unknown}
+TRAVIS_TAG=${TRAVIS_TAG:-empty_tag}
+
+# Add gcloud to PATH.
+source "${HOME}/google-cloud-sdk/path.bash.inc"
+
+# All operations are performed as the service account named in KEYFILE.
+# For all options see:
+# https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
+gcloud auth activate-service-account --key-file "${KEYFILE}"
+
+# For all options see:
+# https://cloud.google.com/sdk/gcloud/reference/config/set
+gcloud config set core/project "${PROJECT}"
+gcloud config set core/disable_prompts true
+gcloud config set core/verbosity debug
+
+# Make build artifacts available to docker build.
+pushd "${BASEDIR}"
+  # Substitute useful travis env variables into appengine env variables.
+  # Each deployment may use only a subset of these, which is fine.
+  yaml=`cat $APPYAML`
+  echo "$yaml" | envsubst '$TRAVIS_TAG, $TRAVIS_COMMIT, $INJECTED_BUCKET, $INJECTED_PROJECT, $INJECTED_DATASET' > $APPYAML
+
+  # Automatically promote the new version to "serving".
+  # For all options see:
+  # https://cloud.google.com/sdk/gcloud/reference/app/deploy
+  gcloud ${BETA} app deploy --promote ${APPYAML}
+popd
+
+exit 0


### PR DESCRIPTION
This change modifies `deploy_app.sh` to support the new (preferable) raw key form of activating service account keys.

As well, this copies the legacy keyfile support where needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/34)
<!-- Reviewable:end -->
