### PR TITLE
Update README instructions and make mlab-testing keys optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,63 +11,29 @@ From the root directory of the repo you're adding to travis:
 git submodule add https://github.com/m-lab/travis.git
 ```
 
-# Creating accounts
+# Creating Service Accounts
 
-From the top level repo (that contains travis as a submodule):
+Install the travis command line tool:
+
+ * https://github.com/travis-ci/travis.rb#installation
+
+From the top level repo (that contains travis as a submodule), run the command:
 
 ```
-mkdir keys
-./travis/create_service_account_and_key.sh \
-    mlab-sandbox cloud-storage-deployer keys/mlab-sandbox.json
-./travis/create_service_account_and_key.sh \
-    mlab-staging cloud-storage-deployer keys/mlab-staging.json
-
-# NB: do not include "." in the resulting tar file.
-pushd keys
-  tar --exclude=*.tar* -cvf service-accounts.tar *.json
-popd
-
-cp ./travis/template-travis.yml .travis.yml
-travis encrypt-file keys/service-accounts.tar --add
+./travis/setup_service_accounts_for_travis.sh
 ```
 
-Update the .travis.yml template to match your repository and deployment needs.
+Once complete, there should be three new service account environment variables
+in the travis environment for your project. You can confirm this using the
+travis CLI:
 
-## Encrypting files for travis
+```
+travis env list
+```
 
-### Recovering if encryption keys are overwritten
+If you require service account credentials in the testing project, pass an
+additional parameter:
 
-Encryption keys may be overwritten by invoking `travis encrypt-file` more than
-once for the same repository.
-
-In the event that the encryption keys are lost, there are a few
-steps that have to be taken to restore functionality.
-
- 1. If the SA keys are available, skip to step 4.
- 2. Create new service accounts or new keys for existing account, for
-    mlab-sandbox and mlab-staging, downloading the json key files.
- 3. Update GCS ACLs, e.g.
-    ```
-    gsutil acl ch -u \
-       legacy-rpm-writer@mlab-sandbox.iam.gserviceaccount.com:WRITE \
-       gs://legacy-rpms-mlab-sandbox
-    ```
- 4. Tar the SA keys:
-    tar cf service-accounts.tar legacy-rpm-writer.mlab*
- 5. Encrypt the tar file:
-    ```
-    travis encrypt-file -f -p service-accounts.tar --repo m-lab/<repo-name>
-    ```
-    Optionally, if you want to provide the keys for some other repos,
-    copy the key and iv values into a command like:
-    ```
-    travis encrypt-file -f -p service-accounts.tar --key \
-      AAA151324478927bbbbbbbbbcccccccccccccdddddddddd53223551235324324 \
-      --iv 632451671306d1842843a792250ce707 --repo gfr10598/ndt-support
-    ```
- 6. Copy the keys printed when you encrypted the tar file,
-    and paste them in place of the three occurances in the script
-    commands below.
- 7. Copy the encrypted tar file to the travis directory (where
-    this script is located).
- 8. Commit to an appropriate branch, generate PR, and send for review.
+```
+./travis/setup_service_accounts_for_travis.sh mlab-testing
+```

--- a/setup_service_accounts_for_travis.sh
+++ b/setup_service_accounts_for_travis.sh
@@ -6,7 +6,7 @@
 # available for travis `deploy` scripts.
 #
 # By default, setup_service_accounts_for_travis.sh creates service accounts in
-# the standard four projects: mlab-sandbox, mlab-staging, and mlab-oti. If you
+# the standard three projects: mlab-sandbox, mlab-staging, and mlab-oti. If you
 # wish to additionally create a service account in the mlab-testing project,
 # pass a single parameter, 'mlab-testing'.
 #

--- a/setup_service_accounts_for_travis.sh
+++ b/setup_service_accounts_for_travis.sh
@@ -5,6 +5,11 @@
 # variables to contain the encoded service account credentials so they are
 # available for travis `deploy` scripts.
 #
+# By default, setup_service_accounts_for_travis.sh creates service accounts in
+# the standard four projects: mlab-sandbox, mlab-staging, and mlab-oti. If you
+# wish to additionally create a service account in the mlab-testing project,
+# pass a single parameter, 'mlab-testing'.
+#
 # In order to perform GCP operations from travis, we must have service account
 # credentials available to travis. This script will create service account
 # credentials for all three M-Lab projects with a name derived from the git
@@ -29,6 +34,10 @@ set -e
 
 BASEDIR="$(dirname "$0")"
 source "${BASEDIR}/support.sh"
+
+# If an argument is given, interpret it as requesting mlab-testing keys also.
+ADD_TESTING_KEYS=${1:+mlab-testing}
+
 
 USAGE="$0"
 IAM_CONSOLE=https://console.cloud.google.com/iam-admin/iam/project
@@ -174,7 +183,7 @@ function main () {
   assert_travis_login_or_die
 
   # For every project.
-  for project in mlab-testing mlab-sandbox mlab-staging mlab-oti ; do
+  for project in ${ADD_TESTING_KEYS} mlab-sandbox mlab-staging mlab-oti ; do
     setup_project $project
   done
 


### PR DESCRIPTION
This change updates the instructions for setting up service account keys in a new project.

As well, this change makes the creation of mlab-testing service account keys optional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/37)
<!-- Reviewable:end -->
