### PR TITLE
one_line_per_minute.awk filters output, but not too much

### DIFF
--- a/one_line_per_minute.awk
+++ b/one_line_per_minute.awk
@@ -1,0 +1,19 @@
+#!/usr/bin/gawk -f
+
+# A helpful script to ensure that commands which produce too much output but
+# also take a long time will be reduced to producing output at most once per
+# minute.  This is useful for ensuring that there is not too much output for
+# Travis, but also that there is never a period where a command doesn't output
+# for ten minutes, causing Travis to think that the command is dead.
+
+# Initialize the output time to the beginning of the epoch.
+BEGIN { next_output_time = 0 }
+
+# On every line of input, check whether it should be echoed or suppressed.
+{
+  current_time = systime()
+  if (current_time > next_output_time) {
+    print $0
+    next_output_time = current_time + 60
+  }
+}

--- a/one_line_per_minute.awk
+++ b/one_line_per_minute.awk
@@ -13,7 +13,7 @@ BEGIN { next_output_time = 0 }
 {
   current_time = systime()
   if (current_time > next_output_time) {
-    print $0
+    print "[" strftime() "]", $0
     next_output_time = current_time + 60
   }
 }


### PR DESCRIPTION
Added a helpful script to prevent the need for complicated I/O tuning on Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/41)
<!-- Reviewable:end -->
