### PR TITLE
allow arbitrary SUBST_TAGS

### DIFF
--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -11,6 +11,8 @@ BASEDIR=${3:?Please provide the base directory containing app.yaml}
 APPYAML=${4:-app.yaml}
 TRAVIS_COMMIT=${TRAVIS_COMMIT:-unknown}
 TRAVIS_TAG=${TRAVIS_TAG:-empty_tag}
+# TODO - should make the default empty, after updating all dependencies.
+SUBST_TAGS=${SUBST_TAGS:-'$TRAVIS_TAG, $TRAVIS_COMMIT, $INJECTED_BUCKET, $INJECTED_PROJECT, $INJECTED_DATASET'}
 
 # Add gcloud to PATH.
 source "${HOME}/google-cloud-sdk/path.bash.inc"
@@ -30,7 +32,7 @@ pushd "${BASEDIR}"
   # Substitute useful travis env variables into appengine env variables.
   # Each deployment may use only a subset of these, which is fine.
   yaml=`cat $APPYAML`
-  echo "$yaml" | envsubst '$TRAVIS_TAG, $TRAVIS_COMMIT, $INJECTED_BUCKET, $INJECTED_PROJECT, $INJECTED_DATASET' > $APPYAML
+  echo "$yaml" | envsubst "'${SUBST_TAGS}'" > $APPYAML
 
   # Automatically promote the new version to "serving".
   # For all options see:


### PR DESCRIPTION
This introduces an environment variable to determine what tags will be substituted (using envsubst) in the app.yaml file.

This simplifies introduction of environment variables for new appengine deployments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/43)
<!-- Reviewable:end -->
