### PR TITLE
Add simple script to create an AppEngine Cloud Scheduler job

### DIFF
--- a/schedule_appengine_job.sh
+++ b/schedule_appengine_job.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# schedule_appengine_job.sh uses the Cloud Schedule API to create AppEngine
+# cron jobs.
+#
+# NOTE: this script DELETEs then CREATEs the job. So, existing jobs will be
+# momentarily removed.
+
+set -ex
+PROJECT=${1:?Please provide project}
+
+name=${2:?Please provide name}
+shift 2  # Pass remaining parameters to command.
+
+# Attempt to delete the job and ignore errors (e.g. does not exist).
+gcloud --project "${PROJECT}" \
+    beta scheduler jobs delete "${name}" 2> /dev/null || :
+
+# Attempt to create the job.
+gcloud --project ${PROJECT} \
+    beta scheduler jobs create app-engine "$name" "$@"

--- a/schedule_appengine_job.sh
+++ b/schedule_appengine_job.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# schedule_appengine_job.sh uses the Cloud Schedule API to create AppEngine
+# schedule_appengine_job.sh uses the Cloud Scheduler API to create AppEngine
 # cron jobs.
 #
 # NOTE: this script DELETEs then CREATEs the job. So, existing jobs will be
-# momentarily removed.
+# momentarily removed. Updates are not yet supported in gcloud.
 
 set -ex
 PROJECT=${1:?Please provide project}


### PR DESCRIPTION
To replace the `cron.yaml` configuration now required by multiple repositories, this change adds a script to create jobs in the new Google Cloud Scheduler service that should perform the same purpose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/44)
<!-- Reviewable:end -->
