### PR TITLE
Change gcloud verbosity to info

### DIFF
--- a/deploy_app.sh
+++ b/deploy_app.sh
@@ -25,7 +25,7 @@ activate_service_account "${KEYNAME}"
 # https://cloud.google.com/sdk/gcloud/reference/config/set
 gcloud config set core/project "${PROJECT}"
 gcloud config set core/disable_prompts true
-gcloud config set core/verbosity debug
+gcloud config set core/verbosity info
 
 # Make build artifacts available to docker build.
 pushd "${BASEDIR}"

--- a/deploy_app_legacy_keyfile.sh
+++ b/deploy_app_legacy_keyfile.sh
@@ -24,7 +24,7 @@ gcloud auth activate-service-account --key-file "${KEYFILE}"
 # https://cloud.google.com/sdk/gcloud/reference/config/set
 gcloud config set core/project "${PROJECT}"
 gcloud config set core/disable_prompts true
-gcloud config set core/verbosity debug
+gcloud config set core/verbosity info
 
 # Make build artifacts available to docker build.
 pushd "${BASEDIR}"

--- a/kubectl.sh
+++ b/kubectl.sh
@@ -25,7 +25,7 @@ activate_service_account "${KEYNAME}"
 # https://cloud.google.com/sdk/gcloud/reference/config/set
 gcloud config set core/project "${PROJECT}"
 gcloud config set core/disable_prompts true
-gcloud config set core/verbosity debug
+gcloud config set core/verbosity info
 
 # Identify the cluster ZONE.
 ZONE=$( gcloud container clusters list \

--- a/kudo.sh
+++ b/kudo.sh
@@ -32,7 +32,7 @@ gcloud auth activate-service-account --key-file "${KEYFILE}"
 # https://cloud.google.com/sdk/gcloud/reference/config/set
 gcloud config set core/project "${PROJECT}"
 gcloud config set core/disable_prompts true
-gcloud config set core/verbosity debug
+gcloud config set core/verbosity info
 
 # Identify the cluster ZONE.
 ZONE=$( gcloud container clusters list \


### PR DESCRIPTION
Evidently, too much information is logged for 'debug' -- https://github.com/m-lab/dev-tracker/issues/194 This change makes it possible to disable that but will require follow-up PRs for all modules that use them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/travis/45)
<!-- Reviewable:end -->
